### PR TITLE
Fix storage usage in review pages

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -17,8 +17,9 @@ function App() {
       <Route path="/admin-login" element={<AdminLogin />} />
       <Route path="/admin/reviews" element={<AdminReviewList />} />
       <Route path="/reviews/:id" element={<ReviewDetail />} />
-      <Route path="*" element={<Navigate to="/" />} />
-      <route path="/admin/review-management" element={<AdminReviewManagement />} />
+      <Route path="/admin/review-management"
+             element={<AdminReviewManagement />} />
+      <Route path="*" element={<Navigate to="/" />} />   {/* catch-all 마지막 */}
     </Routes>
   );
 }

--- a/frontend/src/firebaseConfig.js
+++ b/frontend/src/firebaseConfig.js
@@ -43,8 +43,12 @@ const app = getApps().length ? getApp() : initializeApp(firebaseConfig);
 export const auth = getAuth(app);
 export const db   = getFirestore(app);
 
-// Storage 는 실제 필요할 때만 가져오기 (지연 로딩)
+// Storage는 지연 로딩 + 필요하면 직접 꺼내 씀
 export const getStorageInstance = () => getStorage(app);
+
+// *빌드 시 MyReviews·WriteReview에서 static import가 필요하므로
+//   기본 storage 객체도 함께 내보냅니다.
+export const storage = getStorageInstance();
 
 /* ───────── 자주 쓰는 파이어스토어/스토리지 함수 재수출 ───────── */
 export {

--- a/frontend/src/pages/MyReviews.jsx
+++ b/frontend/src/pages/MyReviews.jsx
@@ -2,22 +2,16 @@ import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import {
   db,
-  storage,
-  collection,
-  query,
-  where,
-  orderBy,
-  getDocs,
-  doc,
-  updateDoc,
-  ref,
-  uploadBytes,
-  getDownloadURL,
+  getStorageInstance,
+  collection, query, where, orderBy, getDocs,
+  doc, updateDoc,
+  ref, uploadBytes, getDownloadURL,
 } from '../firebaseConfig';
 import './MyReviews.css';
 
 export default function MyReviews() {
-  const nav = useNavigate();
+  const nav      = useNavigate();
+  const storage  = getStorageInstance();           // ✅ 확보
 
   /* 리스트 로드 */
   const [loading, setLoading] = useState(true);
@@ -64,20 +58,15 @@ export default function MyReviews() {
     try {
       const urls = [];
       for (const f of files) {
-        const rf = ref(storage, `confirmImages/${Date.now()}_${f.name}`);
-        await uploadBytes(rf, f);
-        urls.push(await getDownloadURL(rf));
+        const r = ref(storage, `confirmImages/${Date.now()}_${f.name}`);
+        await uploadBytes(r, f);
+        urls.push(await getDownloadURL(r));
       }
-      await updateDoc(doc(db, 'reviews', cur.id), {
-        confirmImageUrls: urls,
-        confirmedAt: new Date(),
-      });
-      alert('업로드 완료!');
-      close();
-    } catch (err) {
-      console.error(err);
-      alert('업로드 실패: ' + err.message);
-    }
+      await updateDoc(doc(db, 'reviews', cur.id),
+        {confirmImageUrls: urls, confirmedAt: new Date()});
+      alert('업로드 완료'); setModal(null);
+    } catch (e) { alert('업로드 실패:' + e.message); }
+    finally { setUploading(false); setFiles([]); }
   };
 
   /* ───────── 렌더 ───────── */

--- a/frontend/src/pages/WriteReview.jsx
+++ b/frontend/src/pages/WriteReview.jsx
@@ -14,6 +14,7 @@ import './WriteReview.css';
 
 export default function WriteReview() {
   const navigate = useNavigate();                // SPA 내비게이터
+  const storage   = getStorageInstance();            // ✅ 한 번만 확보
 
   /* ───────────────────────── state ───────────────────────── */
   const [form, setForm] = useState({
@@ -30,8 +31,8 @@ export default function WriteReview() {
     title: '',
     content: '',
   });
-  const [images, setImages] = useState({});
-  const [preview, setPreview] = useState({});
+  const [images] = useState({});
+  const [previews, setPreviews] = useState({});
   const [msg, setMsg] = useState('');
   const [submitting, setSubmitting] = useState(false);
 
@@ -42,15 +43,14 @@ export default function WriteReview() {
   const onFile = (e) => {
     const { name, files } = e.target;
     if (!files[0]) return;
-    setImages({ ...images, [name]: files[0] });
-    setPreview({ ...preview, [name]: URL.createObjectURL(files[0]) });
+    images[name] = files[0];
+    setPreviews({ ...previews, [name]: URL.createObjectURL(files[0]) });
   };
 
   const uploadOne = async (file) => {
-    const storageRef = ref(storage, `reviewImages/${Date.now()}_${file.name}`);
-    const storage = getStorageInstance();
-    await uploadBytes(storageRef, file);
-    return await getDownloadURL(storageRef);
+    const r = ref(storage, `reviewImages/${Date.now()}_${file.name}`);
+    await uploadBytes(r, file);
+    return await getDownloadURL(r);
   };
 
   /* ───────────────────── submit ───────────────────── */
@@ -78,10 +78,6 @@ export default function WriteReview() {
       /* 로그인 화면으로 이동 (SPA 라우팅) */
       navigate('/reviewer-login', { replace: true });
 
-      /* 폼 초기화 */
-      setForm(Object.fromEntries(Object.keys(form).map((k) => [k, ''])));
-      setImages({});
-      setPreview({});
     } catch (err) {
       console.error(err);
       setMsg('❌ 오류: ' + err.message);
@@ -162,9 +158,9 @@ export default function WriteReview() {
               onChange={onFile}
               required={req}
             />
-            {preview[key] && (
-              <img className="thumb" src={preview[key]} alt={key} />
-            )}
+              {previews[key] && (
+                <img className="thumb" src={previews[key]} alt={key} />
+              )}
           </div>
         ))}
 


### PR DESCRIPTION
## Summary
- export a default `storage` instance
- adjust WriteReview to use the new storage instance
- adjust MyReviews to lazily obtain storage
- fix route ordering/case in `App.jsx`

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865272813fc8323a5d4cd9e2c6ea1a6