### PR TITLE
Add storage CORS setup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,17 @@
 ## 더미 데이터
 `backend/dummyData.json`에 예시 리뷰/관리자 계정이 포함돼 있습니다.
 `node backend/seed.js`로 Firestore에 샘플 리뷰를 입력할 수 있습니다.
+## Firebase Storage CORS 설정
+리포지터리 최상위의 `cors.json` 파일을 참고하여 Firebase Storage를 브라우저에서 직접 사용하려면 버킷에 CORS 규칙을 설정해야 합니다. 예시 `cors.json`을 제공하므로 아래 명령어로 적용하세요.
+
+```bash
+# gsutil이 설치되어 있어야 합니다.
+# 프로젝트의 Storage 버킷 이름을 환경변수에 지정
+BUCKET=your-bucket-name
+
+# CORS 규칙 적용
+gsutil cors set cors.json gs://$BUCKET
+```
+
+Netlify 등 도메인에서 업로드 시 `https://hellopiggy.netlify.app`가 허용되도록 설정해야 합니다.
+

--- a/cors.json
+++ b/cors.json
@@ -1,0 +1,8 @@
+[
+  {
+    "origin": ["https://hellopiggy.netlify.app"],
+    "method": ["GET", "POST", "PUT"],
+    "maxAgeSeconds": 3600,
+    "responseHeader": ["Content-Type"]
+  }
+]


### PR DESCRIPTION
## Summary
- document how to configure Firebase Storage CORS
- provide `cors.json` example

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6865337671048323924c2167f6e35111