### PR TITLE
Improve review detail modal and rename ID label

### DIFF
--- a/frontend/src/components/MemberDetailModal.jsx
+++ b/frontend/src/components/MemberDetailModal.jsx
@@ -79,7 +79,7 @@ export default function MemberDetailModal({ member, onClose }) {
                   <div className="info-grid half">
                     <div><label>주문번호</label><p>{review.orderNumber || '-'}</p></div>
                     <div><label>금액</label><p>{review.rewardAmount ? Number(review.rewardAmount).toLocaleString() + '원' : '-'}</p></div>
-                    <div><label>참가자 ID</label><p>{review.participantId || '-'}</p></div>
+                    <div><label>쿠팡 ID</label><p>{review.participantId || '-'}</p></div>
                   </div>
                 </div>
               ))
@@ -89,5 +89,4 @@ export default function MemberDetailModal({ member, onClose }) {
           </div>
         </div>
       </div>
-    </div>
-  );}
+    </div>  );}

--- a/frontend/src/components/ReviewDetailModal.jsx
+++ b/frontend/src/components/ReviewDetailModal.jsx
@@ -28,7 +28,7 @@ export default function ReviewDetailModal({ review, onClose }) {
             <div><label>구매자(수취인)</label><p>{review.name || '-'}</p></div>
             <div><label>전화번호</label><p>{review.phoneNumber || '-'}</p></div>
             <div><label>주소</label><p>{review.address || '-'}</p></div>
-            <div><label>참가자ID</label><p>{review.participantId || '-'}</p></div>
+            <div><label>쿠팡 ID</label><p>{review.participantId || '-'}</p></div>
             <div><label>주문번호</label><p>{review.orderNumber || '-'}</p></div>
             <div><label>금액</label><p>{Number(review.rewardAmount || 0).toLocaleString()}원</p></div>
           </div>

--- a/frontend/src/pages/MyReviews.jsx
+++ b/frontend/src/pages/MyReviews.jsx
@@ -46,6 +46,7 @@ export default function MyReviews() {
   const [uploading, setUploading] = useState(false);
   const [isLoginModalOpen, setIsLoginModalOpen] = useState(false);
   const [currentUser, setCurrentUser] = useState(null);
+  const [imagePreview, setImagePreview] = useState(null);
 
   useEffect(() => {
     const unsubscribe = onAuthStateChanged(auth, async (user) => {
@@ -95,6 +96,8 @@ export default function MyReviews() {
   const handleLoginSuccess = () => setIsLoginModalOpen(false);
   const openModal = (type, review) => { setCurrentReview(review); setModalType(type); setIsEditing(false); };
   const closeModal = () => { setModalType(null); setCurrentReview(null); setFiles([]); setUploading(false); setIsEditing(false); };
+  const openImagePreview = (url) => setImagePreview(url);
+  const closeImagePreview = () => setImagePreview(null);
   
   const handleEdit = () => {
     setIsEditing(true);
@@ -177,6 +180,7 @@ export default function MyReviews() {
   }
 
   return (
+    <>
     <div className="my-wrap">
       {/* ▼▼▼ 이 부분에 버튼 추가 ▼▼▼ */}
       <div className="page-header">
@@ -208,8 +212,8 @@ export default function MyReviews() {
       })}
       
       {modalType && (
-        <div className="modal-back" onClick={closeModal}>
-          <div className="modal" onClick={(e) => e.stopPropagation()}>
+        <div className="modal-back">
+          <div className="modal">
             <button className="close" onClick={closeModal}>✖</button>
             {modalType === 'detail' && (
               <div className="detail-view">
@@ -226,7 +230,7 @@ export default function MyReviews() {
                 </div>
                 {[
                   { key: 'orderNumber', label: '주문번호' }, 
-                  { key: 'participantId', label: '참가자ID'}, 
+                  { key: 'participantId', label: '쿠팡 ID'},
                   { key: 'address', label: '주소' }, 
                   { key: 'bankNumber', label: '계좌번호' }, 
                   { key: 'accountHolderName', label: '예금주' }, 
@@ -252,13 +256,36 @@ export default function MyReviews() {
                     <label>{label}</label>
                     <div className="preview-container">
                       {currentReview[key].map((url, i) => (
-                        <a key={i} href={url} target="_blank" rel="noopener noreferrer"><img src={url} alt={`${label} ${i+1}`} className="thumb" /></a>
+                        <img
+                          key={i}
+                          src={url}
+                          alt={`${label} ${i + 1}`}
+                          className="thumb"
+                          onClick={() => openImagePreview(url)}
+                          style={{ cursor: 'pointer' }}
+                        />
                       ))}
                     </div>
                   </div>
                 )))}
                 
-                {currentReview.confirmImageUrls && currentReview.confirmImageUrls.length > 0 && (<div className="field full-width"><label>리뷰 완료 인증</label><div className="preview-container"> {currentReview.confirmImageUrls.map((url, i) => (<a key={i} href={url} target="_blank" rel="noopener noreferrer"><img src={url} alt={`리뷰인증 ${i+1}`} className="thumb" /></a>))}</div></div>)}
+                {currentReview.confirmImageUrls && currentReview.confirmImageUrls.length > 0 && (
+                  <div className="field full-width">
+                    <label>리뷰 완료 인증</label>
+                    <div className="preview-container">
+                      {currentReview.confirmImageUrls.map((url, i) => (
+                        <img
+                          key={i}
+                          src={url}
+                          alt={`리뷰인증 ${i + 1}`}
+                          className="thumb"
+                          onClick={() => openImagePreview(url)}
+                          style={{ cursor: 'pointer' }}
+                        />
+                      ))}
+                    </div>
+                  </div>
+                )}
                 <div className="modal-actions">
                   {isEditing ? (
                     <>
@@ -285,5 +312,13 @@ export default function MyReviews() {
         </div>
       )}
     </div>
-  );
-}
+    {imagePreview && (
+      <div className="modal-back" onClick={closeImagePreview}>
+        <div className="modal" onClick={(e) => e.stopPropagation()}>
+          <button className="close" onClick={closeImagePreview}>✖</button>
+          <img src={imagePreview} alt="미리보기" style={{ width: '100%' }} />
+        </div>
+      </div>
+    )}
+    </>
+  );}

--- a/frontend/src/pages/WriteReview.jsx
+++ b/frontend/src/pages/WriteReview.jsx
@@ -194,7 +194,7 @@ export default function WriteReview() {
       {isAccountSelected && selectedSubAccountInfo && (
         <form onSubmit={handleSubmit}>
           {[ { key: 'name', label: '구매자(수취인)', value: selectedSubAccountInfo.name }, { key: 'phoneNumber', label: '전화번호', value: selectedSubAccountInfo.phoneNumber }, { key: 'address', label: '주소', value: selectedSubAccountInfo.address }, { key: 'bank', label: '은행', value: selectedSubAccountInfo.bank }, { key: 'bankNumber', label: '계좌번호', value: selectedSubAccountInfo.bankNumber }, { key: 'accountHolderName', label: '예금주', value: selectedSubAccountInfo.accountHolderName }, ].map(({ key, label, value }) => (<div className="field" key={key}><label>{label}</label><input value={value || ''} readOnly style={{background: '#f0f0f0', cursor: 'not-allowed'}}/></div>))}
-          {[ { key: 'participantId', label: '참가자 ID', ph: '참가자 ID를 입력하세요' }, { key: 'orderNumber', label: '주문번호', ph: '주문번호를 그대로 복사하세요' }, { key: 'rewardAmount', label: '금액', ph: '결제금액을 입력하세요' }, ].map(({ key, label, ph }) => (<div className="field" key={key}><label>{label}</label><input name={key} value={form[key]} onChange={onFormChange} placeholder={ph} required/></div>))}
+          {[ { key: 'participantId', label: '쿠팡 ID', ph: '쿠팡 ID를 입력하세요' }, { key: 'orderNumber', label: '주문번호', ph: '주문번호를 그대로 복사하세요' }, { key: 'rewardAmount', label: '금액', ph: '결제금액을 입력하세요' }, ].map(({ key, label, ph }) => (<div className="field" key={key}><label>{label}</label><input name={key} value={form[key]} onChange={onFormChange} placeholder={ph} required/></div>))}
 
           {/* ▼▼▼ 이미지 업로드 UI 수정 ▼▼▼ */}
           <div className="image-upload-group">


### PR DESCRIPTION
## Summary
- prevent accidental modal close in MyReviews
- allow enlarging images in MyReviews
- rename "참가자 ID" label to "쿠팡 ID"

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686efec17f4883238c6bd4422740a8c6