### PR TITLE
Improve MyReviews display

### DIFF
--- a/frontend/src/pages/MyReviews.css
+++ b/frontend/src/pages/MyReviews.css
@@ -23,7 +23,7 @@
 .card.verified .badge { background-color: #4CAF50; }
 .card.rejected .badge { background-color: #F44336; }
 .card.settled .badge { background-color: #9E9E9E; }
-.badge.secondary { background-color: #e9ecef; color: #495057; }
+.badge.secondary { background-color: #9E9E9E; color: #fff; }
 
 /* 상품 정보 섹션 */
 .product-details { background-color: #f8f9fa; padding: 16px; border-radius: 8px; margin-bottom: 16px; border: 1px solid #e9ecef; }
@@ -31,6 +31,15 @@
 .product-details p { margin: 0 0 6px; font-size: 14px; color: #495057; line-height: 1.5; }
 .guide-box { margin-top: 12px; border-top: 1px solid #e0e0e0; padding-top: 12px; }
 .guide-box p { white-space: pre-wrap; }
+.guide-box .toggle-btn {
+  margin-top: 8px;
+  background: none;
+  border: none;
+  color: #007bff;
+  cursor: pointer;
+  font-size: 14px;
+  padding: 0;
+}
 
 /* 가격 및 반려 사유 */
 .price { font-size: 20px; font-weight: bold; text-align: right; margin-bottom: 16px; }

--- a/frontend/src/pages/MyReviews.jsx
+++ b/frontend/src/pages/MyReviews.jsx
@@ -10,6 +10,24 @@ import {
 import LoginModal from '../components/LoginModal';
 import './MyReviews.css';
 
+function GuideToggle({ text }) {
+  const [expanded, setExpanded] = useState(false);
+  const lines = text.split('\n');
+  const preview = lines.slice(0, 4).join('\n');
+  const hasMore = lines.length > 4;
+  return (
+    <div className="guide-box">
+      <strong>가이드:</strong>
+      <p>{expanded || !hasMore ? text : preview}</p>
+      {hasMore && (
+        <button className="toggle-btn" onClick={() => setExpanded(!expanded)}>
+          {expanded ? '접기 ▲' : '더보기 ▼'}
+        </button>
+      )}
+    </div>
+  );
+}
+
 const getStatusInfo = (review) => {
   const { status } = review;
   switch (status) {
@@ -199,11 +217,19 @@ export default function MyReviews() {
       {rows.length === 0 ? <p>작성한 리뷰가 없습니다.</p> : rows.map((r) => {
         const statusInfo = getStatusInfo(r);
         const participantName = r.subAccountInfo?.name || r.mainAccountInfo?.name || '알 수 없음';
-        const participantType = r.subAccountInfo ? `타계정(${participantName})` : '본계정';
+        const participantType = r.subAccountInfo ? participantName : '본계정';
         return (
           <div className={`card ${statusInfo.className}`} key={r.id}>
             <div className="card-head"><div><span className="badge">{statusInfo.text}</span><span className="badge secondary">{participantType}</span></div><span className="timestamp">{r.createdAt?.seconds ? new Date(r.createdAt.seconds * 1000).toLocaleString() : ''}</span></div>
-            {r.productInfo && (<div className="product-details"><h4>{r.productInfo.productName}</h4><p><strong>리뷰 종류:</strong> {r.productInfo.reviewType}</p>{r.productInfo.guide && (<div className="guide-box"><strong>가이드:</strong><p>{r.productInfo.guide}</p></div>)}</div>)}
+            {r.productInfo && (
+              <div className="product-details">
+                <h4>{r.productInfo.productName}</h4>
+                <p>
+                  <strong>리뷰 종류:</strong> {r.productInfo.reviewType}
+                </p>
+                {r.productInfo.guide && <GuideToggle text={r.productInfo.guide} />}
+              </div>
+            )}
             {statusInfo.reason && <div className="rejection-reason"><strong>반려 사유:</strong> {statusInfo.reason}</div>}
             <div className="price">{Number(r.rewardAmount || 0).toLocaleString()}원</div>
             <div className="btn-wrap"><button onClick={() => openModal('detail', r)}>제출 내역 상세</button><button className="outline" onClick={() => openModal('upload', r)} disabled={r.status !== 'submitted' && r.status !== 'rejected'}>리뷰 인증하기</button></div>


### PR DESCRIPTION
## Summary
- allow toggling of long guide text
- show sub account name without prefix
- unify secondary badge style with settled status

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f02e79a948323a88257eb7d55a283