### PR TITLE
Add new fields for purchase form and admin views

### DIFF
--- a/frontend/src/pages/AdminReviewManagement.jsx
+++ b/frontend/src/pages/AdminReviewManagement.jsx
@@ -206,6 +206,9 @@ export default function AdminReviewManagement() {
               <th onClick={() => requestSort('mainAccountName')} className="sortable">본계정<SortIndicator columnKey="mainAccountName" /></th>
               <th onClick={() => requestSort('name')} className="sortable">타계정<SortIndicator columnKey="name" /></th>
               <th onClick={() => requestSort('phoneNumber')} className="sortable">전화번호<SortIndicator columnKey="phoneNumber" /></th>
+              <th onClick={() => requestSort('paymentType')} className="sortable">결제유형<SortIndicator columnKey="paymentType" /></th>
+              <th onClick={() => requestSort('productType')} className="sortable">상품종류<SortIndicator columnKey="productType" /></th>
+              <th onClick={() => requestSort('reviewOption')} className="sortable">리뷰종류<SortIndicator columnKey="reviewOption" /></th>
               <th>리뷰 인증</th>
               <th>작업</th>
             </tr>
@@ -223,6 +226,9 @@ export default function AdminReviewManagement() {
               <th><input type="text" name="mainAccountName" value={filters.mainAccountName} onChange={handleFilterChange} /></th>
               <th><input type="text" name="name" value={filters.name} onChange={handleFilterChange} /></th>
               <th><input type="text" name="phoneNumber" value={filters.phoneNumber} onChange={handleFilterChange} /></th>
+              <th></th>
+              <th></th>
+              <th></th>
               <th>
                 <select name="reviewConfirm" value={filters.reviewConfirm} onChange={handleFilterChange}>
                   <option value="all">전체</option>
@@ -244,6 +250,9 @@ export default function AdminReviewManagement() {
                 <td>{r.mainAccountName || '-'}</td>
                 <td>{r.name || '-'}</td>
                 <td>{r.phoneNumber || '-'}</td>
+                <td>{r.paymentType || '-'}</td>
+                <td>{r.productType || '-'}</td>
+                <td>{r.reviewOption || '-'}</td>
                 <td>
                   <button className={`link-button ${r.confirmImageUrls?.length > 0 ? 'completed' : ''}`} onClick={() => openDetailModal(r)}>
                     {r.confirmImageUrls?.length > 0 ? 'O' : 'X'}

--- a/frontend/src/pages/AdminSettlement.jsx
+++ b/frontend/src/pages/AdminSettlement.jsx
@@ -240,6 +240,9 @@ const processedRows = useMemo(() => {
               <th onClick={() => requestSort('mainAccountName')} className="sortable">본계정 이름<SortIndicator columnKey="mainAccountName" /></th>
               <th onClick={() => requestSort('subAccountName')} className="sortable">타계정 이름<SortIndicator columnKey="subAccountName" /></th>
               <th onClick={() => requestSort('phoneNumber')} className="sortable">전화번호<SortIndicator columnKey="phoneNumber" /></th>
+              <th onClick={() => requestSort('paymentType')} className="sortable">결제유형<SortIndicator columnKey="paymentType" /></th>
+              <th onClick={() => requestSort('productType')} className="sortable">상품종류<SortIndicator columnKey="productType" /></th>
+              <th onClick={() => requestSort('reviewOption')} className="sortable">리뷰종류<SortIndicator columnKey="reviewOption" /></th>
               <th onClick={() => requestSort('orderNumber')} className="sortable">주문번호<SortIndicator columnKey="orderNumber" /></th>
               <th>리뷰 인증</th>
               <th onClick={() => requestSort('rewardAmount')} className="sortable">정산 금액<SortIndicator columnKey="rewardAmount" /></th>
@@ -252,6 +255,9 @@ const processedRows = useMemo(() => {
               <th><input type="text" name="mainAccountName" value={filters.mainAccountName} onChange={handleFilterChange} /></th>
               <th><input type="text" name="subAccountName" value={filters.subAccountName} onChange={handleFilterChange} /></th>
               <th><input type="text" name="phoneNumber" value={filters.phoneNumber} onChange={handleFilterChange} /></th>
+              <th></th>
+              <th></th>
+              <th></th>
               <th><input type="text" name="orderNumber" value={filters.orderNumber} onChange={handleFilterChange} /></th>
               <th>
                 <select name="reviewConfirm" value={filters.reviewConfirm} onChange={handleFilterChange}>
@@ -272,6 +278,9 @@ const processedRows = useMemo(() => {
                 <td>{r.mainAccountName || '-'}</td>
                 <td>{r.subAccountName || '-'}</td>
                 <td>{r.phoneNumber || '-'}</td>
+                <td>{r.paymentType || '-'}</td>
+                <td>{r.productType || '-'}</td>
+                <td>{r.reviewOption || '-'}</td>
                 <td>{r.orderNumber || '-'}</td>
                 <td>
                   <button className={`link-button ${r.confirmImageUrls?.length > 0 ? 'completed' : ''}`} onClick={() => openDetailModal(r)}>

--- a/frontend/src/pages/AdminSettlementComplete.jsx
+++ b/frontend/src/pages/AdminSettlementComplete.jsx
@@ -190,6 +190,9 @@ export default function AdminSettlementComplete() {
               <th onClick={() => requestSort('mainAccountName')} className="sortable">본계정 이름<SortIndicator columnKey="mainAccountName" /></th>
               <th onClick={() => requestSort('subAccountName')} className="sortable">타계정 이름<SortIndicator columnKey="subAccountName" /></th>
               <th onClick={() => requestSort('phoneNumber')} className="sortable">전화번호<SortIndicator columnKey="phoneNumber" /></th>
+              <th onClick={() => requestSort('paymentType')} className="sortable">결제유형<SortIndicator columnKey="paymentType" /></th>
+              <th onClick={() => requestSort('productType')} className="sortable">상품종류<SortIndicator columnKey="productType" /></th>
+              <th onClick={() => requestSort('reviewOption')} className="sortable">리뷰종류<SortIndicator columnKey="reviewOption" /></th>
               <th onClick={() => requestSort('orderNumber')} className="sortable">주문번호<SortIndicator columnKey="orderNumber" /></th>
               <th>리뷰 인증</th>
               <th onClick={() => requestSort('rewardAmount')} className="sortable">정산 금액<SortIndicator columnKey="rewardAmount" /></th>
@@ -202,6 +205,9 @@ export default function AdminSettlementComplete() {
               <th><input type="text" name="mainAccountName" value={filters.mainAccountName} onChange={handleFilterChange} /></th>
               <th><input type="text" name="subAccountName" value={filters.subAccountName} onChange={handleFilterChange} /></th>
               <th><input type="text" name="phoneNumber" value={filters.phoneNumber} onChange={handleFilterChange} /></th>
+              <th></th>
+              <th></th>
+              <th></th>
               <th><input type="text" name="orderNumber" value={filters.orderNumber} onChange={handleFilterChange} /></th>
               <th>
                 <select name="reviewConfirm" value={filters.reviewConfirm} onChange={handleFilterChange}>
@@ -223,6 +229,9 @@ export default function AdminSettlementComplete() {
                 <td>{r.mainAccountName || '-'}</td>
                 <td>{r.subAccountName || '-'}</td>
                 <td>{r.phoneNumber || '-'}</td>
+                <td>{r.paymentType || '-'}</td>
+                <td>{r.productType || '-'}</td>
+                <td>{r.reviewOption || '-'}</td>
                 <td>{r.orderNumber || '-'}</td>
                 <td>
                   <button

--- a/frontend/src/pages/WriteReview.jsx
+++ b/frontend/src/pages/WriteReview.jsx
@@ -32,7 +32,13 @@ export default function WriteReview() {
   const [isAccountModalOpen, setIsAccountModalOpen] = useState(false);
   
   const [form, setForm] = useState({
-    participantId: '', orderNumber: '', rewardAmount: '', subAccountId: null,
+    participantId: '',
+    orderNumber: '',
+    rewardAmount: '',
+    subAccountId: null,
+    paymentType: '현영',
+    productType: '실배송',
+    reviewOption: '별점',
   });
   
   const [images, setImages] = useState({});
@@ -112,13 +118,19 @@ export default function WriteReview() {
       }
 
       const reviewData = {
-        mainAccountId: currentUser.uid, subAccountId: form.subAccountId,
-        productId: selectedProduct.id, productName: selectedProduct.productName,
-        reviewType: selectedProduct.reviewType, createdAt: serverTimestamp(),
-        status: 'submitted', 
+        mainAccountId: currentUser.uid,
+        subAccountId: form.subAccountId,
+        productId: selectedProduct.id,
+        productName: selectedProduct.productName,
+        reviewType: selectedProduct.reviewType,
+        createdAt: serverTimestamp(),
+        status: 'submitted',
         orderNumber: form.orderNumber,
         rewardAmount: form.rewardAmount, // 콤마 없는 숫자 문자열 저장
         participantId: form.participantId,
+        paymentType: form.paymentType,
+        productType: form.productType,
+        reviewOption: form.reviewOption,
         ...urlMap,
       };
 
@@ -141,10 +153,12 @@ export default function WriteReview() {
   // ▼▼▼ onFormChange 함수 수정 (금액 포맷팅 로직 대응) ▼▼▼
   const onFormChange = (e) => {
     const { name, value } = e.target;
-    // 주문번호와 금액 필드는 숫자 이외의 문자 제거
+
     if (name === 'orderNumber' || name === 'rewardAmount') {
       const numericValue = value.replace(/[^0-9]/g, '');
       setForm({ ...form, [name]: numericValue });
+    } else if (name === 'productType') {
+      setForm({ ...form, productType: value, reviewOption: '별점' });
     } else {
       setForm({ ...form, [name]: value });
     }
@@ -209,13 +223,46 @@ export default function WriteReview() {
           </div>
           <div className="field">
             <label>금액</label>
-            <input 
-              name="rewardAmount" 
-              value={form.rewardAmount ? Number(form.rewardAmount).toLocaleString() : ''} 
-              onChange={onFormChange} 
-              placeholder="결제금액을 입력하세요" 
+            <input
+              name="rewardAmount"
+              value={form.rewardAmount ? Number(form.rewardAmount).toLocaleString() : ''}
+              onChange={onFormChange}
+              placeholder="결제금액을 입력하세요"
               required
             />
+          </div>
+          <div className="field">
+            <label>결제유형</label>
+            <select name="paymentType" value={form.paymentType} onChange={onFormChange}>
+              <option value="현영">현영</option>
+              <option value="자율결제">자율결제</option>
+            </select>
+          </div>
+          <div className="field">
+            <label>상품종류</label>
+            <select name="productType" value={form.productType} onChange={onFormChange}>
+              <option value="실배송">실배송</option>
+              <option value="빈박스">빈박스</option>
+            </select>
+          </div>
+          <div className="field">
+            <label>리뷰종류</label>
+            <select name="reviewOption" value={form.reviewOption} onChange={onFormChange}>
+              {form.productType === '빈박스' ? (
+                <>
+                  <option value="별점">별점</option>
+                  <option value="텍스트">텍스트</option>
+                </>
+              ) : (
+                <>
+                  <option value="별점">별점</option>
+                  <option value="텍스트">텍스트</option>
+                  <option value="포토">포토</option>
+                  <option value="프리미엄포토">프리미엄포토</option>
+                  <option value="프리미엄영상">프리미엄영상</option>
+                </>
+              )}
+            </select>
           </div>
           {/* ▲▲▲ 수정 완료 ▲▲▲ */}
 


### PR DESCRIPTION
## Summary
- extend purchase form with payment, product type, and review option fields
- store these new values in review submissions
- show payment type, product type, and review option on admin tables

## Testing
- `npm run build` *(fails: `vite` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f40160454832395ca6c219dd14c87