### PR TITLE
Add per-item edit buttons

### DIFF
--- a/frontend/src/components/AccountModal.css
+++ b/frontend/src/components/AccountModal.css
@@ -134,6 +134,7 @@
 .account-actions {
   display: flex;
   align-items: center;
+  justify-content: flex-end;
   gap: 8px; /* 버튼 사이의 간격 */
   flex-shrink: 0; /* 버튼 영역이 줄어들지 않도록 설정 */
 }
@@ -146,6 +147,7 @@
   border: none;
   cursor: pointer;
   transition: background-color 0.2s;
+  margin-left: 2px;
 }
 
 /* Edit Button Style */

--- a/frontend/src/components/AccountModal.jsx
+++ b/frontend/src/components/AccountModal.jsx
@@ -206,10 +206,27 @@ export default function AccountModal({ onClose, onSelectAccount, onAddressAdded 
               <h4>등록된 계정 목록을 선택하세요</h4>
               {subAccounts.map(acc => (
                 <div key={acc.id} className="sub-account-item">
-                  <span onClick={() => handleSelectSubAccount(acc)} className="account-info">{acc.name} ({acc.phoneNumber})</span>
+                  <span
+                    onClick={() => handleSelectSubAccount(acc)}
+                    className="account-info"
+                  >
+                    {acc.name} ({acc.phoneNumber})
+                  </span>
                   <div className="account-actions">
-                    <button onClick={() => handleEditClick(acc)} className="edit-btn">수정</button>
-                    <button onClick={() => handleDeleteClick(acc.id)} className="delete-btn">삭제</button>
+                    <button
+                      type="button"
+                      onClick={() => handleEditClick(acc)}
+                      className="edit-btn"
+                    >
+                      수정
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => handleDeleteClick(acc.id)}
+                      className="delete-btn"
+                    >
+                      삭제
+                    </button>
                   </div>
                 </div>
               ))}


### PR DESCRIPTION
## Summary
- show edit/delete actions beside each sub account
- tweak styles so buttons align right

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870f3efb1e483239af8da374cbc3bfa