### PR TITLE
Fix account modal layout for small screens

### DIFF
--- a/frontend/src/components/AccountModal.css
+++ b/frontend/src/components/AccountModal.css
@@ -26,6 +26,14 @@
   position: relative;
   z-index: 1001;
   text-align: center;
+  box-sizing: border-box; /* 모바일에서 패딩 포함 크기 계산 */
+}
+
+@media (max-width: 480px) {
+  .account-modal {
+    width: 95%;
+    padding: 20px;
+  }
 }
 
 /* Close Button */


### PR DESCRIPTION
## Summary
- prevent AccountModal from overflowing on mobile by including padding in the width via `box-sizing`
- reduce modal width and padding on screens <= 480px

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6871010e5a9c8323b5248ec3eed54361